### PR TITLE
Added support for special prices in beta version

### DIFF
--- a/v1.9.x - Transparent (beta)/app/code/community/MercadoPago/Standard/Model/Checkout.php
+++ b/v1.9.x - Transparent (beta)/app/code/community/MercadoPago/Standard/Model/Checkout.php
@@ -101,7 +101,7 @@ class MercadoPago_Standard_Model_Checkout extends Mage_Payment_Model_Method_Abst
                 "picture_url" => $imagem,
                 "category_id" => Mage::getModel('mercadopago_transparent/transparent')->getConfigData('category_id'),
                 "quantity" => (int) number_format($item->getQtyOrdered(), 0, '.', ''),
-                "unit_price" => (float) number_format($prod->getPrice(), 2, '.', '')
+                "unit_price" => (float) number_format($prod->getFinalPrice(), 2, '.', '')
             );
             
         }

--- a/v1.9.x - Transparent (beta)/app/code/community/MercadoPago/Transparent/Model/Transparent.php
+++ b/v1.9.x - Transparent (beta)/app/code/community/MercadoPago/Transparent/Model/Transparent.php
@@ -275,7 +275,7 @@ Tente novamente em alguns minutos. \t";
                 "picture_url" => $imagem,
                 "category_id" => $this->getConfigData('category_id'),
                 "quantity" => (int) number_format($item->getQtyOrdered(), 0, '.', ''),
-                "unit_price" => (float) number_format($prod->getPrice(), 2, '.', '')
+                "unit_price" => (float) number_format($prod->getFinalPrice(), 2, '.', '')
             );
             
         }


### PR DESCRIPTION
En la versión Transparent Beta, toma el precio común del producto de magento.
Si hay un producto con un special price esa fecha por ej con un descuento, el checkout a mercadopago nunca lo toma y se fija en el precio original

Esto está probado y corregido en este pull-request
