### PR TITLE
Fix product model loading for SKUs with dashes for non bundle products

### DIFF
--- a/v1.6.x - 1.9.x/app/code/community/Mpexpress/Model/Express.php
+++ b/v1.6.x - 1.9.x/app/code/community/Mpexpress/Model/Express.php
@@ -49,30 +49,17 @@ class Mpexpress_Model_Express extends Mage_Payment_Model_Method_Abstract{
         $orderIncrementId = Mage::getSingleton('checkout/session')->getLastRealOrderId();
         $order = Mage::getModel('sales/order')->loadByIncrementId($orderIncrementId);
         $customer = Mage::getSingleton('customer/session')->getCustomer();
-        $name = '#' . $orderIncrementId . ' - ';
+        $name = '#' . $orderIncrementId;
         $model = Mage::getModel('catalog/product');
 
         $quote = Mage::getSingleton('checkout/session')->getQuote();
 
         foreach ($order->getAllVisibleItems() as $item) {
-            //modificado por e-values para permitir el manejo de kits
-            if (strpos($item->getSku(), '-') !== false) {
-                $skus = explode("-", $item->getSku());
-                $prod = $model->loadByAttribute('sku', $skus[0]);
-            } else {
-                $prod = $model->loadByAttribute('sku', $item->getSku());
+            $prod = $model->load($item->getProductId());
+
+            if ($prod) {
+                $image = $prod->getImageUrl();
             }
-
-            //get methods and each find getImage
-            $methods = get_class_methods($prod);
-            foreach($methods as $method):
-                if($method == "getImageUrl"):
-                    $image[] = $prod->getImageUrl();
-                endif;
-            endforeach;
-
-
-            $name .= $item->getName();
         }
 
 
@@ -125,13 +112,6 @@ class Mpexpress_Model_Express extends Mage_Payment_Model_Method_Abstract{
 
         $item_price = number_format($item_price, 2, '.', '');
 
-
-        //case no exist function getImage in the $prod no generate item on the array
-        $image_items = "";
-        if (count($image) > 0):
-            $image_items = $image[0];
-        endif;
-
         $items = array(
             array (
             "id" => $orderIncrementId,
@@ -140,7 +120,7 @@ class Mpexpress_Model_Express extends Mage_Payment_Model_Method_Abstract{
             "quantity" => 1,
             "unit_price" => round($item_price, 2),
             "currency_id" => $this->getConfigData('currency'),
-            "picture_url"=> $image_items,
+            "picture_url"=> $image,
             "category_id"=> $this->getConfigData('category_id')
             )
         );


### PR DESCRIPTION
This pull request fixes the logic for the old SKU bundle / simple product check. My new code skips loading a product using its SKU entirely and uses its product_id instead. Since every single product (including bundles) in the store must have an unique product_id, loading by id is better than checking the SKU type and processing it.

I also removed the name of the product from the "item title", leaving only the order ID itself. I did this because the API seems to support multiple item checkout, but the module currently does not. So right now, you can only "checkout an order" not "a list of products".