### PR TITLE
strtoupper in coupon_code

### DIFF
--- a/1.6.x-1.9.x/app/code/community/MercadoPago/Core/Model/Core.php
+++ b/1.6.x-1.9.x/app/code/community/MercadoPago/Core/Model/Core.php
@@ -304,7 +304,7 @@ class MercadoPago_Core_Model_Core
 
             $couponInfo = $this->getCouponInfo($coupon, $couponCode);
             $preference['coupon_amount'] = $couponInfo['coupon_amount'];
-            $preference['coupon_code'] = $couponInfo['coupon_code'];
+            $preference['coupon_code'] = strtoupper($couponInfo['coupon_code']);
             $preference['campaign_id'] = $couponInfo['campaign_id'];
 
         }


### PR DESCRIPTION
A API não aceita coupon_code minúsculo, por isso converte para maiúsculo o coupon.