### PR TITLE
Erro Cep com caracteres não numéricos.

### DIFF
--- a/1.6.x-1.9.x/app/code/community/MercadoPago/MercadoEnvios/Model/Shipping/Carrier/MercadoEnvios.php
+++ b/1.6.x-1.9.x/app/code/community/MercadoPago/MercadoEnvios/Model/Shipping/Carrier/MercadoEnvios.php
@@ -78,7 +78,7 @@ class MercadoPago_MercadoEnvios_Model_Shipping_Carrier_MercadoEnvios
             if (empty($shippingAddress)) {
                 return null;
             }
-            $postcode = $shippingAddress->getPostcode();
+            $postcode = preg_replace('/\D/', '', $shippingAddress->getPostcode());
 
             try {
                 $helperMe = Mage::helper('mercadopago_mercadoenvios');


### PR DESCRIPTION
O módulo envia como parâmetro o "zip_code" conforme aparece no input, logo se o campo tiver máscara ou o usuário digitar um caractere não numérico, volta o erro "Este método está temporariamente indisponível. - Invalid zip_code".
Essa pequena correção somente limpa o valor para ficar somente números.