### PR TITLE
Corrige o erro invalid_transaction_amount

### DIFF
--- a/1.6.x-1.9.x/app/code/community/MercadoPago/Core/Model/Core.php
+++ b/1.6.x-1.9.x/app/code/community/MercadoPago/Core/Model/Core.php
@@ -278,9 +278,9 @@ class MercadoPago_Core_Model_Core
 
         $preference['description'] = Mage::helper('mercadopago')->__("Order # %s in store %s", $orderId, Mage::getBaseUrl(Mage_Core_Model_Store::URL_TYPE_LINK, true));
         if (isset($paymentInfo['transaction_amount'])) {
-            $preference['transaction_amount'] = (float)$paymentInfo['transaction_amount'];
+            $preference['transaction_amount'] = round((float)$paymentInfo['transaction_amount'],2);
         } else {
-            $preference['transaction_amount'] = (float)$this->getAmount();
+            $preference['transaction_amount'] = round((float)$this->getAmount(),2);
         }
 
         $preference['external_reference'] = $orderId;

--- a/1.6.x-1.9.x/app/code/community/MercadoPago/Core/controllers/CheckoutController.php
+++ b/1.6.x-1.9.x/app/code/community/MercadoPago/Core/controllers/CheckoutController.php
@@ -121,7 +121,7 @@ class MercadoPago_Core_CheckoutController
                 }
             }
 
-            if ($status == 'approved' || $status == 'pending'){
+            if ($status == 'approved' || $status == 'pending' || $status == 'in_process'){
                 $this->_redirect(self::SUCCESS_PAGE_MAGENTO, $this->_request->getParams());
                 return;
             } else {

--- a/1.6.x-1.9.x/app/design/frontend/base/default/template/mercadopago/custom_ticket/info.phtml
+++ b/1.6.x-1.9.x/app/design/frontend/base/default/template/mercadopago/custom_ticket/info.phtml
@@ -1,11 +1,8 @@
 <p><strong><?php echo $this->getMethod()->getTitle() ?></strong></p>
 
-<?php if( Mage::app()->getRequest()->getRouteName() == "sales" || Mage::app()->getFrontController()->getAction()->getFullActionName() == 'checkout_onepage_success' ): ?> 
+<?php if (null !== $this->getInfo()->getOrder()): ?>
 
-    <?php
-        $info_payment = $this->getInfoPayment();
-    ?>
-
+    <?php $info_payment = $this->getInfoPayment(); ?>
 
     <?php if(isset($info_payment['payment_id']) && $info_payment['payment_id']['value'] != ""): ?>
         <p><?php echo $this->__('Payment Id (Mercado Pago): %s', $info_payment['payment_id']['value']); ?></p>
@@ -19,16 +16,13 @@
         <p><?php echo $this->__('Payment Status Detail: %s', $info_payment['status_detail']['value']); ?></p>
     <?php endif; ?>
 
-    <p>
-        <?php echo $this->__('Generate the ticket and pay it wherever you want.'); ?>
-    </p>
-    <p>
-        <?php echo $this->__('Will be approved within 2 business days.'); ?>
-    </p>
-    <p><?php echo $this->__('Click on the link to generate the ticket'); ?>.</p>
-
-    <a href="<?php echo urldecode($info_payment['activation_uri']['value']); ?>" target="_blank">
-        <?php echo $this->__('Generate Ticket'); ?>
-    </a>
+    <?php if(isset($info_payment['activation_uri']) && isset($info_payment['activation_uri']['value'])): ?>
+        <p><?php echo $this->__('Generate the ticket and pay it wherever you want.'); ?></p>
+        <p><?php echo $this->__('Will be approved within 2 business days.'); ?></p>
+        <p><?php echo $this->__('Click on the link to generate the ticket'); ?>.</p>
+        <a href="<?php echo urldecode($info_payment['activation_uri']['value']); ?>" target="_blank">
+            <?php echo $this->__('Generate Ticket'); ?>
+        </a>
+    <?php endif;?>
 
 <?php endif;?>


### PR DESCRIPTION
- Quando o valor total do pedido possui mais de 2 casas decimais, o que ocorre em função de regras de promoção, é gerado o erro invalid_transaction_amount pela API. Este commit arredonda o valor da request para 2 casas decimais.
- Quando o pedido está em revisão manual o sistema jogava na tela de falha de pegamento o que deixava os clientes confusos
- Exibe o link de impressão do boleto